### PR TITLE
为小诗与音乐详情补充阅读进度框

### DIFF
--- a/src/components/Cards.jsx
+++ b/src/components/Cards.jsx
@@ -1,14 +1,12 @@
 import { BookOpenText } from "@phosphor-icons/react/BookOpenText";
 import { CalendarBlank } from "@phosphor-icons/react/CalendarBlank";
 import { ChatCircleDots } from "@phosphor-icons/react/ChatCircleDots";
-import { Disc } from "@phosphor-icons/react/Disc";
 import { Eye } from "@phosphor-icons/react/Eye";
 import { FolderOpen } from "@phosphor-icons/react/FolderOpen";
-import { MicrophoneStage } from "@phosphor-icons/react/MicrophoneStage";
-import { Playlist } from "@phosphor-icons/react/Playlist";
 import { Tag } from "@phosphor-icons/react/Tag";
 import { TextAa } from "@phosphor-icons/react/TextAa";
 import { getPostFirstParagraph } from "../richContent.js";
+import { getMusicSectionIcon } from "../musicSections.js";
 import { formatContentDate, getPostWordCount } from "../siteUtils.js";
 
 export function ArticleCover({ post, className, emptyClassName = "", imageClassName = "", placeholderClassName = "", iconSize = 34, loading = "lazy", fetchPriority }) {
@@ -29,6 +27,6 @@ export function ArticleCard({ post, stats, featured = false }) {
 
 export function MusicReviewCard({ entry, section, stats }) {
   const summary = entry.excerpt || getPostFirstParagraph(entry);
-  const CreditIcon = section === "songs" ? Playlist : section === "artists" ? MicrophoneStage : Disc;
+  const CreditIcon = getMusicSectionIcon(section);
   return <a className={`article-card music-review-card${entry.image ? " has-image" : ""}`} href={`#/music/${section}/${entry.slug}`}><div className="music-review-layout">{entry.image && <span className="article-card-media music-review-media"><img className="article-card-media-image" src={entry.image} alt="" loading="lazy" decoding="async" /></span>}<div className="article-card-copy"><span className="category">标题</span><h2>{entry.title}</h2>{summary && <div className="article-card-excerpt"><span>{entry.excerpt ? "摘要" : "正文预览"}</span><p>{summary}</p></div>}<div className="music-review-credits"><CreditIcon size={16} weight="duotone" /><span><strong>{entry.sourceTitle || entry.title}</strong>{(entry.sourceMeta || entry.kind) && <em>{entry.sourceMeta || entry.kind}</em>}</span></div><div className="post-meta"><span><TextAa size={16} />{getPostWordCount(entry)} 字</span><span><CalendarBlank size={16} />{formatContentDate(entry.date)}</span><span><Eye size={16} />{stats?.views || 0}</span><span><ChatCircleDots size={16} />{stats?.comments || 0}</span></div></div></div></a>;
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -12,12 +12,14 @@ import { UserCircleCheck } from "@phosphor-icons/react/UserCircleCheck";
 import { X } from "@phosphor-icons/react/X";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { navItems } from "../content/index.js";
+import { getDetailReadingTarget } from "../detailReading.js";
 
-function useArticleReadingProgress(route) {
+function useDetailReadingProgress(route) {
   const [progress, setProgress] = useState(0);
 
   useEffect(() => {
-    if (!route.startsWith("/post/")) {
+    const readingTarget = getDetailReadingTarget(route);
+    if (!readingTarget) {
       setProgress(0);
       return undefined;
     }
@@ -29,7 +31,7 @@ function useArticleReadingProgress(route) {
 
     const update = () => {
       frame = 0;
-      const nextArticleBody = document.querySelector(".article-page .article-body");
+      const nextArticleBody = document.querySelector(readingTarget);
       if (nextArticleBody !== articleBody) {
         resizeObserver?.disconnect();
         articleBody = nextArticleBody;
@@ -90,7 +92,8 @@ export function ArticleOutlinePopover({ items, open, activeId, onSelect }) {
 export function Header({ route, theme, menuOpen, onMenu, onTheme, onSearch, onSettings, viewer, onAccount, hasArticleOutline, articleOutlineOpen, onArticleOutline, onCloseArticleOutline }) {
   const navRef = useRef(null);
   const headerCenterRef = useRef(null);
-  const articleReadingProgress = useArticleReadingProgress(route);
+  const detailReadingTarget = getDetailReadingTarget(route);
+  const detailReadingProgress = useDetailReadingProgress(route);
   const [indicator, setIndicator] = useState({ x: 0, ready: false });
   const [collapsed, setCollapsed] = useState(false);
   const [morphing, setMorphing] = useState("");
@@ -210,7 +213,7 @@ export function Header({ route, theme, menuOpen, onMenu, onTheme, onSearch, onSe
   const collapseHeader = () => morphHeader(true);
   const restoreHeader = () => morphHeader(false);
   return <header className={`site-header${hasArticleOutline ? " has-article-outline" : ""}${collapsed ? " is-collapsed" : ""}`}>
-    <div ref={headerCenterRef} className={`header-center material-panel${route.startsWith("/post/") ? " has-article-reading-progress" : ""}${morphing ? ` is-morphing is-${morphing}` : ""}`} style={{ "--article-reading-progress": `${articleReadingProgress}%`, "--article-reading-progress-opacity": articleReadingProgress > 0 ? 1 : 0 }}>
+    <div ref={headerCenterRef} className={`header-center material-panel${detailReadingTarget ? " has-article-reading-progress" : ""}${morphing ? ` is-morphing is-${morphing}` : ""}`} style={{ "--article-reading-progress": `${detailReadingProgress}%`, "--article-reading-progress-opacity": detailReadingProgress > 0 ? 1 : 0 }}>
       <nav ref={navRef} className={menuOpen ? "main-nav is-open" : "main-nav"} aria-label="主导航">
         <span className={indicator.ready ? "nav-active-indicator is-ready" : "nav-active-indicator"} style={{ "--indicator-x": `${indicator.x}px` }} aria-hidden="true" />
         {navItems.map(([path, label]) => {

--- a/src/detailReading.js
+++ b/src/detailReading.js
@@ -1,0 +1,9 @@
+const DETAIL_READING_TARGETS = [
+  ["/post/", ".article-page .article-body"],
+  ["/poem/", ".poem-page article"],
+  ["/music/", ".music-detail-page .article-detail"],
+];
+
+export function getDetailReadingTarget(route) {
+  return DETAIL_READING_TARGETS.find(([prefix]) => route.startsWith(prefix))?.[1] || "";
+}

--- a/src/musicSections.js
+++ b/src/musicSections.js
@@ -1,0 +1,13 @@
+import { Disc } from "@phosphor-icons/react/Disc";
+import { MicrophoneStage } from "@phosphor-icons/react/MicrophoneStage";
+import { Playlist } from "@phosphor-icons/react/Playlist";
+
+export const musicSections = [
+  { id: "songs", label: "歌曲", icon: Playlist },
+  { id: "artists", label: "音乐人", icon: MicrophoneStage },
+  { id: "albums", label: "专辑", icon: Disc },
+];
+
+export function getMusicSectionIcon(section) {
+  return musicSections.find((item) => item.id === section)?.icon || Disc;
+}

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -1,7 +1,6 @@
 import { Article } from "@phosphor-icons/react/Article";
 import { BookOpenText } from "@phosphor-icons/react/BookOpenText";
 import { ChatCircleDots } from "@phosphor-icons/react/ChatCircleDots";
-import { Disc } from "@phosphor-icons/react/Disc";
 import { Eye } from "@phosphor-icons/react/Eye";
 import { Feather } from "@phosphor-icons/react/Feather";
 import { MusicNotes } from "@phosphor-icons/react/MusicNotes";
@@ -12,6 +11,7 @@ import { authorProfile, musicReviews, poems, posts, siteConfig } from "../conten
 import { ArticleCover } from "../components/Cards.jsx";
 import { HeroShell } from "../components/PageHero.jsx";
 import { useHorizontalScroller } from "../hooks.js";
+import { getMusicSectionIcon } from "../musicSections.js";
 import { getPostFirstParagraph } from "../richContent.js";
 import { formatContentDate, getPostWordCount } from "../siteUtils.js";
 import { getHomeContent } from "./homeContent.js";
@@ -170,10 +170,13 @@ export function HomePage({ stats }) {
             <a href="#/music">音乐手记</a>
           </header>
           {latestMusic.length ? <div className="home-refresh-list home-refresh-mini-track" {...musicScroller}>
-            {latestMusic.map((entry) => <a href={`#/music/${entry.section}/${entry.slug}`} key={`${entry.section}-${entry.slug}`}>
-              <Disc size={21} weight="duotone" />
-              <span><small>{entry.kind} · {formatContentDate(entry.date).slice(0, 10)}</small><strong>{entry.title}</strong></span>
-            </a>)}
+            {latestMusic.map((entry) => {
+              const EntryIcon = getMusicSectionIcon(entry.section);
+              return <a href={`#/music/${entry.section}/${entry.slug}`} key={`${entry.section}-${entry.slug}`}>
+                <EntryIcon size={21} weight="duotone" />
+                <span><small>{entry.kind} · {formatContentDate(entry.date).slice(0, 10)}</small><strong>{entry.title}</strong></span>
+              </a>;
+            })}
           </div> : <div className="home-refresh-empty" role="status"><MusicNotes size={29} weight="duotone" /><strong>暂无音乐</strong></div>}
         </section>
       </div>

--- a/src/pages/MusicPage.jsx
+++ b/src/pages/MusicPage.jsx
@@ -2,11 +2,8 @@ import { ArrowLeft } from "@phosphor-icons/react/ArrowLeft";
 import { ArrowRight } from "@phosphor-icons/react/ArrowRight";
 import { CalendarBlank } from "@phosphor-icons/react/CalendarBlank";
 import { ChatCircleDots } from "@phosphor-icons/react/ChatCircleDots";
-import { Disc } from "@phosphor-icons/react/Disc";
 import { Eye } from "@phosphor-icons/react/Eye";
-import { MicrophoneStage } from "@phosphor-icons/react/MicrophoneStage";
 import { MusicNotes } from "@phosphor-icons/react/MusicNotes";
-import { Playlist } from "@phosphor-icons/react/Playlist";
 import { TextAa } from "@phosphor-icons/react/TextAa";
 import { lazy, Suspense, useEffect, useState } from "react";
 import { MusicReviewCard } from "../components/Cards.jsx";
@@ -15,17 +12,13 @@ import { PageHero } from "../components/PageHero.jsx";
 import { CommentsSection } from "../community/CommentsSection.jsx";
 import { musicReviews, siteConfig } from "../content/index.js";
 import { usePagination, useResponsivePageSize } from "../hooks.js";
+import { musicSections } from "../musicSections.js";
 import { go, parseHashQuery } from "../routeState.js";
 import { formatContentDate, getPostWordCount } from "../siteUtils.js";
 import { NotFound } from "./NotFound.jsx";
 
 const RichArticleContent = lazy(() => import("../RichArticleContent.jsx").then((module) => ({ default: module.RichArticleContent })));
 
-const musicSections = [
-  { id: "songs", label: "歌曲", icon: Playlist },
-  { id: "artists", label: "音乐人", icon: MicrophoneStage },
-  { id: "albums", label: "专辑", icon: Disc },
-];
 export function MusicPage({ stats }) {
   const requestedSection = new URLSearchParams(parseHashQuery()).get("section");
   const [section, setSection] = useState(() => musicSections.some((item) => item.id === requestedSection) ? requestedSection : "songs");

--- a/test/detail-reading.test.mjs
+++ b/test/detail-reading.test.mjs
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getDetailReadingTarget } from "../src/detailReading.js";
+
+test("detail routes expose the content region used by the shared reading progress", () => {
+  assert.equal(getDetailReadingTarget("/post/example"), ".article-page .article-body");
+  assert.equal(getDetailReadingTarget("/poem/example"), ".poem-page article");
+  assert.equal(getDetailReadingTarget("/music/albums/example"), ".music-detail-page .article-detail");
+  assert.equal(getDetailReadingTarget("/posts"), "");
+  assert.equal(getDetailReadingTarget("/music"), "");
+});

--- a/test/music-sections.test.mjs
+++ b/test/music-sections.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getMusicSectionIcon, musicSections } from "../src/musicSections.js";
+
+test("songs, artists, and albums keep distinct shared icons", () => {
+  assert.deepEqual(musicSections.map((section) => section.id), ["songs", "artists", "albums"]);
+  assert.equal(new Set(musicSections.map((section) => section.icon)).size, 3);
+  for (const section of musicSections) assert.equal(getMusicSectionIcon(section.id), section.icon);
+  assert.equal(getMusicSectionIcon("unknown"), musicSections[2].icon);
+});


### PR DESCRIPTION
## 更新
- 小诗与音乐详情页复用文章详情页的阅读进度边框
- 首页音乐卡片按歌曲、音乐人、专辑显示对应图标
- 抽取共享映射并补充单元测试

## 验证
- pnpm check
- 与 Fonstage 共用实现完成 320 / 768 / 1280 视口浏览器验收