### PR TITLE
Fix code title centering and update article categories

### DIFF
--- a/src/pages/PostsPage.jsx
+++ b/src/pages/PostsPage.jsx
@@ -16,7 +16,7 @@ import { usePagination, useResponsivePageSize } from "../hooks.js";
 import { lockPageScroll } from "../lockPageScroll.js";
 import { ARTICLE_INDEX_DEFAULTS, articleIndexState, parseHash, parseHashQuery, updateArticleIndexState } from "../routeState.js";
 
-const POST_CATEGORIES = ["随笔", "小说", "评论", "记录", "笔记", "站务"];
+const POST_CATEGORIES = ["随笔", "小说", "评谈", "记录", "笔记", "指南"];
 
 export function PostsPage({ query, stats }) {
   const parameters = useMemo(() => new URLSearchParams(query), [query]);

--- a/src/styles.css
+++ b/src/styles.css
@@ -444,7 +444,7 @@ button,input { font:inherit; } a { color:inherit; text-decoration:none; } button
 .rich-article blockquote p { margin:.2em 0; }
 .rich-article :not(pre):not(.code-window-body)>code { padding:.12em .42em; border:1px solid color-mix(in srgb,var(--accent) 18%,var(--line)); border-radius:6px; background:var(--surface-soft); color:color-mix(in srgb,var(--accent) 70%,var(--text)); font:500 .88em/1.6 ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace; }
 .code-window { margin:2.3em 0; overflow:hidden; border:1px solid color-mix(in srgb,var(--blue) 34%,#111522); border-radius:17px; background:#151521; box-shadow:0 18px 46px rgba(25,15,35,.22); }
-.code-window-bar { min-height:46px; display:grid; grid-template-columns:1fr auto 1fr; align-items:center; gap:12px; padding:0 13px 0 16px; border-bottom:1px solid rgba(255,255,255,.075); background:linear-gradient(180deg,#30303d,#262632); color:#d8d2df; }
+.code-window-bar { min-height:46px; display:grid; grid-template-columns:1fr auto 1fr; align-items:center; gap:12px; padding:0 16px; border-bottom:1px solid rgba(255,255,255,.075); background:linear-gradient(180deg,#30303d,#262632); color:#d8d2df; }
 .code-window-lights { display:flex; gap:7px; }
 .code-window-lights i { width:11px; height:11px; border-radius:50%; background:#ff6b64; box-shadow:inset 0 -1px 2px rgba(0,0,0,.18); }
 .code-window-lights i:nth-child(2) { background:#f4bd4f; }
@@ -627,7 +627,6 @@ footer::before { content:""; position:absolute; top:0; left:50%; width:min(1180p
   .rich-article h2 { font-size:1.45em; }
   .article-outline { top:78px; }
   .code-window { margin-inline:-2px; border-radius:15px; }
-  .code-window-bar { grid-template-columns:auto minmax(0,1fr) auto; }
   .code-window-title { text-align:center; }
   .code-line { grid-template-columns:38px minmax(0,1fr); padding-right:18px; }
   .rich-article blockquote { grid-template-columns:25px minmax(0,1fr); padding:17px 18px; }


### PR DESCRIPTION
## Summary\n- center code-window titles exactly at all responsive widths\n- rename the public theme article category tabs from 评论 to 评谈 and 站务 to 指南\n- keep the clean theme free of legacy article-category aliases and content\n\n## Checks\n- [ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND] No package.json (or package.yaml, or package.json5) was found in "/Users/fons/Desktop/Fonstage（New）".\n- responsive browser geometry at 320, 431, 768, and 1280 px