### PR TITLE
chore: tighten backend schema hygiene

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Test and build
         run: pnpm check
 
+      - name: Apply D1 migrations
+        if: github.ref == 'refs/heads/main'
+        run: pnpm db:migrate:cloudflare
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Upload branch preview to Cloudflare Workers
         if: github.ref != 'refs/heads/main'
         run: pnpm exec wrangler versions upload

--- a/migrations/0017_backend_schema_hygiene.sql
+++ b/migrations/0017_backend_schema_hygiene.sql
@@ -1,0 +1,45 @@
+PRAGMA defer_foreign_keys = ON;
+
+-- Published content has always been sourced from Git. Abort instead of
+-- discarding data if an installation ever wrote to the retired D1 table.
+CREATE TABLE backend_hygiene_content_guard (
+  entry_count INTEGER NOT NULL CHECK (entry_count = 0)
+);
+
+INSERT INTO backend_hygiene_content_guard (entry_count)
+SELECT COUNT(*) FROM content_entries;
+
+DROP TABLE backend_hygiene_content_guard;
+DROP TABLE content_entries;
+
+-- Migration 0009 copied article counters into the shared content table. Merge
+-- once more so installations upgraded from an older runtime cannot lose a
+-- higher counter, then remove the retired duplicate table.
+INSERT INTO content_metrics (content_type, content_slug, views, updated_at)
+SELECT 'post', slug, views, updated_at
+FROM article_metrics
+WHERE 1
+ON CONFLICT(content_type, content_slug) DO UPDATE SET
+  views = MAX(content_metrics.views, excluded.views),
+  updated_at = MAX(content_metrics.updated_at, excluded.updated_at);
+
+DROP TABLE article_metrics;
+
+-- The API has stored at most 100 KiB per avatar since the limit was tightened.
+-- Copying into the stricter table deliberately aborts the migration if a
+-- third-party installation still has a larger legacy row; no avatar is
+-- silently discarded.
+CREATE TABLE user_avatars_next (
+  user_id TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  image_data BLOB NOT NULL,
+  mime_type TEXT NOT NULL CHECK (mime_type IN ('image/jpeg', 'image/png', 'image/webp')),
+  byte_size INTEGER NOT NULL CHECK (byte_size > 0 AND byte_size <= 102400),
+  updated_at INTEGER NOT NULL
+);
+
+INSERT INTO user_avatars_next (user_id, image_data, mime_type, byte_size, updated_at)
+SELECT user_id, image_data, mime_type, byte_size, updated_at
+FROM user_avatars;
+
+DROP TABLE user_avatars;
+ALTER TABLE user_avatars_next RENAME TO user_avatars;

--- a/test/backend-schema-hygiene.test.mjs
+++ b/test/backend-schema-hygiene.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createClient } from "@libsql/client";
+import { migrateTurso, readMigrations } from "../scripts/migrate-turso.mjs";
+
+async function tableNames(client) {
+  const result = await client.execute("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name");
+  return result.rows.map((row) => String(row.name));
+}
+
+test("backend hygiene preserves runtime data while removing retired storage", async () => {
+  const client = createClient({ url: ":memory:" });
+  const migrations = await readMigrations();
+  const cleanupIndex = migrations.findIndex((migration) => migration.name.endsWith("_backend_schema_hygiene.sql"));
+  assert.notEqual(cleanupIndex, -1);
+
+  try {
+    await migrateTurso({ client, apply: true, migrations: migrations.slice(0, cleanupIndex) });
+    const now = Date.now();
+    await client.execute({
+      sql: `INSERT INTO users
+        (id, email, username, password_hash, password_salt, nickname, role, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, 'member', 'active', ?, ?)`,
+      args: ["user-1", "user-1@example.invalid", "reader01", "hash", "salt", "读者", now, now],
+    });
+    await client.execute({
+      sql: "INSERT INTO user_avatars (user_id, image_data, mime_type, byte_size, updated_at) VALUES (?, ?, 'image/webp', ?, ?)",
+      args: ["user-1", new Uint8Array(100 * 1024), 100 * 1024, now],
+    });
+    await client.execute({
+      sql: "INSERT INTO article_metrics (slug, views, updated_at) VALUES ('example', 7, ?)",
+      args: [now - 1],
+    });
+    await client.execute({
+      sql: "INSERT INTO content_metrics (content_type, content_slug, views, updated_at) VALUES ('post', 'example', 9, ?)",
+      args: [now],
+    });
+
+    await migrateTurso({ client, apply: true, migrations: [migrations[cleanupIndex]] });
+
+    const tables = await tableNames(client);
+    assert.equal(tables.includes("content_entries"), false);
+    assert.equal(tables.includes("article_metrics"), false);
+    assert.equal(tables.includes("comment_reports"), true);
+    assert.equal(tables.includes("admin_audit"), true);
+    assert.equal(tables.includes("friend_applications"), true);
+    assert.deepEqual((await client.execute("SELECT views FROM content_metrics WHERE content_type = 'post' AND content_slug = 'example'")).rows, [{ views: 9 }]);
+    assert.deepEqual((await client.execute("SELECT byte_size, length(image_data) AS stored_bytes FROM user_avatars WHERE user_id = 'user-1'")).rows, [{ byte_size: 102400, stored_bytes: 102400 }]);
+    await client.execute({
+      sql: `INSERT INTO users
+        (id, email, username, password_hash, password_salt, nickname, role, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, 'member', 'active', ?, ?)`,
+      args: ["user-2", "user-2@example.invalid", "reader02", "hash", "salt", "读者二", now, now],
+    });
+    await assert.rejects(client.execute({
+      sql: "INSERT INTO user_avatars (user_id, image_data, mime_type, byte_size, updated_at) VALUES ('user-2', ?, 'image/webp', 102401, ?)",
+      args: [new Uint8Array(102401), now],
+    }), /CHECK constraint failed/u);
+  } finally {
+    await client.close();
+  }
+});
+
+test("backend hygiene refuses to discard repository-era D1 content", async () => {
+  const client = createClient({ url: ":memory:" });
+  const migrations = await readMigrations();
+  const cleanupIndex = migrations.findIndex((migration) => migration.name.endsWith("_backend_schema_hygiene.sql"));
+
+  try {
+    await migrateTurso({ client, apply: true, migrations: migrations.slice(0, cleanupIndex) });
+    const now = Date.now();
+    await client.execute({
+      sql: `INSERT INTO users
+        (id, email, username, password_hash, password_salt, nickname, role, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, 'member', 'active', ?, ?)`,
+      args: ["user-1", "user-1@example.invalid", "reader01", "hash", "salt", "读者", now, now],
+    });
+    await client.execute({
+      sql: `INSERT INTO content_entries
+        (id, type, slug, title, status, data, created_at, updated_at, author_id)
+        VALUES ('entry-1', 'post', 'legacy-entry', 'Legacy', 'draft', '{}', ?, ?, 'user-1')`,
+      args: [now, now],
+    });
+
+    await assert.rejects(
+      migrateTurso({ client, apply: true, migrations: [migrations[cleanupIndex]] }),
+      /CHECK constraint failed/u,
+    );
+    assert.equal((await client.execute("SELECT COUNT(*) AS count FROM content_entries")).rows[0].count, 1);
+  } finally {
+    await client.close();
+  }
+});

--- a/test/vercel-runtime-integration.test.mjs
+++ b/test/vercel-runtime-integration.test.mjs
@@ -36,7 +36,7 @@ test("Vercel and Turso execute the shared auth and comment API end to end", asyn
 
   try {
     const migration = await migrateTurso({ client, apply: true });
-    assert.equal(migration.applied.length, 16);
+    assert.equal(migration.applied.length, 17);
 
     const runtime = await request("/site/runtime");
     assert.equal(runtime.status, 200);


### PR DESCRIPTION
## 改动
- 以新迁移安全移除退役的 D1 内容表和重复文章统计表
- 将头像数据库约束收紧至 100 KiB，升级时不静默删除超限数据
- GitHub Actions 在部署 Worker 前显式应用 D1 迁移
- 增加保留数据、阻止误删和 Turso 集成回归测试

## 验证
- pnpm check（66 项测试及生产构建通过）
- Wrangler 本地 D1 从 0001 至 0017 全量迁移通过
- wrangler deploy --dry-run 通过
- src 与 public Git tree 哈希相对 main 完全不变