### PR TITLE
fix: restore admin comment submission

### DIFF
--- a/functions/_lib/abuse.js
+++ b/functions/_lib/abuse.js
@@ -362,6 +362,9 @@ export async function insertCommentWithRateLimitsAtomically(db, {
     ? `AND (SELECT COUNT(*) FROM rate_limits WHERE key IN (${policies.map(() => "?").join(", ")})
       AND comment_mutation_token = ?) = ?`
     : "";
+  const rateReadyBindings = policies.length
+    ? [...policies.map((policy) => policy.key), claimToken, policies.length]
+    : [];
   const statements = [db.prepare(`INSERT INTO comment_mutations
     (id, user_id, request_hash, claim_token, status, created_at, updated_at)
     VALUES (?, ?, ?, ?, 'pending', ?, ?)
@@ -412,7 +415,7 @@ export async function insertCommentWithRateLimitsAtomically(db, {
     replyToCommentId, userId, body, now, now,
     id, claimToken, id, totalMaximum, role, userId, userMaximum,
     target.type, target.slug, targetMaximum,
-    ...policies.map((policy) => policy.key), claimToken, policies.length,
+    ...rateReadyBindings,
   ));
   // The CHECK constraint deliberately aborts this batch when the claimed
   // mutation could not create its comment. That rolls back every rate-window

--- a/test/admin-comment-regression.test.mjs
+++ b/test/admin-comment-regression.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createClient } from "@libsql/client";
+import { insertCommentWithRateLimitsAtomically } from "../functions/_lib/abuse.js";
+import { migrateTurso } from "../scripts/migrate-turso.mjs";
+import { createTursoD1Database } from "../server/turso-d1.js";
+
+test("administrator comments work with an empty rate-limit policy set", async () => {
+  const client = createClient({ url: ":memory:" });
+  try {
+    await migrateTurso({ client, apply: true });
+    const db = createTursoD1Database({ client });
+    const now = Date.now();
+    const userId = "admin-1";
+    const commentId = "admin-comment-1";
+
+    await client.execute({
+      sql: `INSERT INTO users
+        (id, username, password_hash, password_salt, nickname, role, status, created_at, updated_at)
+        VALUES (?, 'siteadmin', 'hash', 'salt', '管理员', 'admin', 'active', ?, ?)`,
+      args: [userId, now, now],
+    });
+    await client.execute({
+      sql: "INSERT INTO account_usage (user_id, comments_created, updated_at) VALUES (?, 0, ?)",
+      args: [userId, now],
+    });
+
+    const result = await insertCommentWithRateLimitsAtomically(db, {
+      id: commentId,
+      userId,
+      role: "admin",
+      target: { type: "post", slug: "site-about" },
+      body: "管理员评论",
+      requestHash: "admin-comment-request-hash",
+      now,
+      env: {},
+    }, []);
+
+    assert.equal(result.created, 1);
+    assert.equal(result.rateLimit, null);
+    assert.equal((await client.execute({
+      sql: "SELECT COUNT(*) AS count FROM comments WHERE id = ? AND user_id = ?",
+      args: [commentId, userId],
+    })).rows[0].count, 1);
+    assert.equal((await client.execute("SELECT COUNT(*) AS count FROM rate_limits")).rows[0].count, 0);
+    assert.equal((await client.execute({
+      sql: "SELECT status FROM comment_mutations WHERE id = ?",
+      args: [commentId],
+    })).rows[0].status, "completed");
+  } finally {
+    await client.close();
+  }
+});


### PR DESCRIPTION
修复管理员评论提交在零限频策略下的 SQL 参数绑定错位问题。

- 仅在存在评论限频策略时绑定对应的 rate-limit 参数
- 保持管理员绕过评论限频的既有语义
- 新增管理员评论回归测试，验证评论成功写入、幂等记录完成且不写入 rate_limits

该问题由评论原子提交逻辑引入，普通 member 路径不受影响。