### PR TITLE
chore: remove obsolete poem comment spacing rule

### DIFF
--- a/src/styles/community.css
+++ b/src/styles/community.css
@@ -127,7 +127,6 @@
 .comments-section { width:min(790px,100%); margin:72px auto 10px; padding-top:34px; border-top:0; }
 .comments-material-panel { width:min(854px,100%); margin:34px auto 10px; padding:28px 32px; border-radius:24px; }
 .comments-material-panel>.comments-section { width:100%; margin:0; padding:0; border:0; }
-.poem-comments { margin-top:72px; }
 .about-layout.material-panel,.article-page.material-panel { border-radius:28px; }
 .article-page.material-panel { margin-block:32px 36px; padding-inline:34px; padding-bottom:28px; }
 .comments-heading { display:flex; align-items:center; justify-content:space-between; gap:16px; margin-bottom:15px; }


### PR DESCRIPTION
删除已无任何 JSX 使用者的 `.poem-comments { margin-top:72px; }` 死 CSS。

仅 1 行删除；当前小诗评论区继续使用共享 `comments-material-panel` 的 34px 间距，前端计算样式与视觉输出不变。