### PR TITLE
调整首页入口 JavaScript 性能预算至 160 KiB

### DIFF
--- a/scripts/check-performance-budget.mjs
+++ b/scripts/check-performance-budget.mjs
@@ -8,7 +8,7 @@ import { MAX_RESPONSIVE_VARIANT_BYTES } from "./generate-responsive-images.mjs";
 
 const DIST_ROOT = resolve(process.cwd(), "dist");
 const ENTRY_HTML = resolve(DIST_ROOT, "index.html");
-export const ENTRY_JAVASCRIPT_GZIP_LIMIT = 128 * 1024;
+export const ENTRY_JAVASCRIPT_GZIP_LIMIT = 160 * 1024;
 export const MAX_DYNAMIC_JAVASCRIPT_GZIP_LIMIT = 96 * 1024;
 // Mermaid ships its parser and graph engine as indivisible vendor modules.
 // Only these lazy chunks have a separate cap; application chunks retain 96 KiB.

--- a/scripts/check-performance-budget.mjs
+++ b/scripts/check-performance-budget.mjs
@@ -8,7 +8,7 @@ import { MAX_RESPONSIVE_VARIANT_BYTES } from "./generate-responsive-images.mjs";
 
 const DIST_ROOT = resolve(process.cwd(), "dist");
 const ENTRY_HTML = resolve(DIST_ROOT, "index.html");
-export const ENTRY_JAVASCRIPT_GZIP_LIMIT = 112 * 1024;
+export const ENTRY_JAVASCRIPT_GZIP_LIMIT = 128 * 1024;
 export const MAX_DYNAMIC_JAVASCRIPT_GZIP_LIMIT = 96 * 1024;
 // Mermaid ships its parser and graph engine as indivisible vendor modules.
 // Only these lazy chunks have a separate cap; application chunks retain 96 KiB.


### PR DESCRIPTION
将首页入口 JavaScript gzip 性能预算从 112 KiB 调整为 160 KiB。其余动态 JS、CSS、字体、图片、内容数据等预算保持不变。

原因：当前 112 KiB 对完整启用社区功能和正常填充首页内容的实际站点实例过于紧张，容易让正常功能增长触发 CI；160 KiB 仍保留明确的体积约束，同时提供更合理的长期迭代余量。