### PR TITLE
修复关闭社区时的测试兼容性

### DIFF
--- a/fonscape.config.js
+++ b/fonscape.config.js
@@ -8,7 +8,7 @@ const siteConfig = {
   postCategories: ["随笔", "评谈", "记录", "笔记", "指南"],
   showPoems: false,
   showMusic: false,
-  showCommunity: true,
+  showCommunity: false,
   home: {
     eyebrow: "PERSONAL BLOG",
     title: "我的博客",

--- a/fonscape.config.js
+++ b/fonscape.config.js
@@ -8,7 +8,7 @@ const siteConfig = {
   postCategories: ["随笔", "评谈", "记录", "笔记", "指南"],
   showPoems: false,
   showMusic: false,
-  showCommunity: false,
+  showCommunity: true,
   home: {
     eyebrow: "PERSONAL BLOG",
     title: "我的博客",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,7 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
+import siteConfig from "./fonscape.config.js";
 
 export default defineConfig({
   testDir: "./e2e",
+  testIgnore: siteConfig.showCommunity === false ? ["**/comment-reliability.spec.mjs"] : [],
   fullyParallel: false,
   workers: 1,
   retries: process.env.CI ? 1 : 0,

--- a/test/admin-setup-ui.test.mjs
+++ b/test/admin-setup-ui.test.mjs
@@ -4,8 +4,10 @@ import { fileURLToPath } from "node:url";
 import { JSDOM } from "jsdom";
 import { act, createElement } from "react";
 import { createServer } from "vite";
+import { siteConfig } from "../src/siteConfig.js";
 
 const sourceRoot = new URL("../", import.meta.url);
+const communityTest = siteConfig.showCommunity ? test : test.skip;
 
 let viteServer;
 let createRoot;
@@ -196,7 +198,7 @@ async function setInputValue(input, value) {
   });
 }
 
-test("the admin setup route renders its frame without the public shell", async () => {
+communityTest("the admin setup route renders its frame without the public shell", async () => {
   const { document } = installDom();
   installFetch();
   await mountApp();
@@ -217,7 +219,7 @@ test("the admin setup route renders its frame without the public shell", async (
   assert.equal(token.hasAttribute("hidden"), false);
 });
 
-test("the password control toggles visibility while retaining the entered value", async () => {
+communityTest("the password control toggles visibility while retaining the entered value", async () => {
   const { document } = installDom();
   installFetch();
   await mountApp();
@@ -241,7 +243,7 @@ test("the password control toggles visibility while retaining the entered value"
   assert.equal(visibilityButton.getAttribute("aria-pressed"), "false");
 });
 
-test("an asynchronous setup status failure is shown in the form", async () => {
+communityTest("an asynchronous setup status failure is shown in the form", async () => {
   const { document } = installDom();
   installFetch({ setup: { status: 503, payload: { error: "初始化服务暂时不可用" } } });
   await mountApp();
@@ -254,7 +256,7 @@ test("an asynchronous setup status failure is shown in the form", async () => {
   assert.ok(document.querySelector("#admin-setup-token"));
 });
 
-test("an already initialized site redirects away from setup", async () => {
+communityTest("an already initialized site redirects away from setup", async () => {
   const { document, replaceCalls } = installDom();
   installFetch({ setup: { initialized: true } });
   await mountApp();


### PR DESCRIPTION
修复 `showCommunity: false` 时测试套件仍假设社区功能可用的问题。

修复内容：
- 管理员初始化 UI 测试仅在社区功能启用时运行；关闭社区时不再错误要求 `/admin/setup` 可访问。
- Playwright 评论可靠性 E2E 仅在社区功能启用时运行；关闭社区后仍继续执行与社区无关的页面加载 E2E。

兼容性复核：曾在该分支临时将 `showCommunity` 设为 `false`，完整跑过 `pnpm check`、Playwright、Cloudflare Worker dry-run 与 production audit，全部通过；随后已恢复主题默认 `showCommunity: true`。最终 PR 不修改默认配置。